### PR TITLE
fix: document & handle all APIs w/o project scope

### DIFF
--- a/client/api_key.go
+++ b/client/api_key.go
@@ -1,0 +1,4 @@
+package client
+
+// CRUDL operations on API keys are all tenant scoped.
+// See: hubble/services/service/user/internal/service/apikey/apikey_acl.go

--- a/client/cluster_edge_native.go
+++ b/client/cluster_edge_native.go
@@ -8,8 +8,12 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/client/apiutil"
 )
 
+// CRUDL operations on edge registration tokens are all tenant scoped.
+// See: hubble/services/svccore/perms/edgetoken_acl.go
+
 func (h *V1Client) GetRegistrationToken(tokenName string) (string, error) {
-	params := clientV1.NewV1EdgeTokensListParamsWithContext(h.ctx)
+	// ACL scoped to tenant only
+	params := clientV1.NewV1EdgeTokensListParams()
 	resp, err := h.Client.V1EdgeTokensList(params)
 	if err != nil {
 		return "", err
@@ -27,7 +31,8 @@ func (h *V1Client) GetRegistrationToken(tokenName string) (string, error) {
 }
 
 func (h *V1Client) CreateRegistrationToken(tokenName string, body *models.V1EdgeTokenEntity) (string, error) {
-	params := clientV1.NewV1EdgeTokensCreateParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1EdgeTokensCreateParams().
 		WithBody(body)
 	_, err := h.Client.V1EdgeTokensCreate(params)
 	if err != nil {

--- a/client/filter.go
+++ b/client/filter.go
@@ -8,8 +8,12 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/client/apiutil"
 )
 
+// CRUDL operations on tag filters are all tenant scoped.
+// See: hubble/services/svccore/perms/filter_acl.go
+
 func (h *V1Client) CreateTagFilter(body *models.V1TagFilter) (*models.V1UID, error) {
-	params := clientV1.NewV1TagFiltersCreateParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1TagFiltersCreateParams().
 		WithBody(body)
 	resp, err := h.Client.V1TagFiltersCreate(params)
 	if err != nil {
@@ -19,7 +23,8 @@ func (h *V1Client) CreateTagFilter(body *models.V1TagFilter) (*models.V1UID, err
 }
 
 func (h *V1Client) UpdateTagFilter(uid string, body *models.V1TagFilter) error {
-	params := clientV1.NewV1TagFilterUIDUpdateParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1TagFilterUIDUpdateParams().
 		WithUID(uid).
 		WithBody(body)
 	_, err := h.Client.V1TagFilterUIDUpdate(params)
@@ -27,7 +32,8 @@ func (h *V1Client) UpdateTagFilter(uid string, body *models.V1TagFilter) error {
 }
 
 func (h *V1Client) GetTagFilter(uid string) (*models.V1TagFilterSummary, error) {
-	params := clientV1.NewV1TagFilterUIDGetParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1TagFilterUIDGetParams().
 		WithUID(uid)
 	resp, err := h.Client.V1TagFilterUIDGet(params)
 	if err != nil {
@@ -37,7 +43,8 @@ func (h *V1Client) GetTagFilter(uid string) (*models.V1TagFilterSummary, error) 
 }
 
 func (h *V1Client) ListTagFilters() (*models.V1FiltersSummary, error) {
-	params := clientV1.NewV1FiltersListParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1FiltersListParams().
 		WithLimit(apiutil.Ptr(int64(0)))
 	resp, err := h.Client.V1FiltersList(params)
 	if err != nil {
@@ -60,7 +67,8 @@ func (h *V1Client) GetTagFilterByName(name string) (*models.V1FilterSummary, err
 }
 
 func (h *V1Client) DeleteTag(uid string) error {
-	params := clientV1.NewV1TagFilterUIDDeleteParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1TagFilterUIDDeleteParams().
 		WithUID(uid)
 	_, err := h.Client.V1TagFilterUIDDelete(params)
 	return err

--- a/client/project.go
+++ b/client/project.go
@@ -7,8 +7,12 @@ import (
 	"github.com/spectrocloud/palette-api-go/models"
 )
 
+// CRUDL operations on projects are all tenant scoped.
+// See: hubble/services/svccore/perms/user_acl.go
+
 func (h *V1Client) CreateProject(body *models.V1ProjectEntity) (string, error) {
-	params := clientV1.NewV1ProjectsCreateParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1ProjectsCreateParams().
 		WithBody(body)
 	resp, err := h.Client.V1ProjectsCreate(params)
 	if err != nil {
@@ -33,7 +37,8 @@ func (h *V1Client) GetProjectUID(projectName string) (string, error) {
 }
 
 func (h *V1Client) GetProjectByUID(uid string) (*models.V1Project, error) {
-	params := clientV1.NewV1ProjectsUIDGetParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1ProjectsUIDGetParams().
 		WithUID(uid)
 	resp, err := h.Client.V1ProjectsUIDGet(params)
 	if err != nil {
@@ -43,7 +48,8 @@ func (h *V1Client) GetProjectByUID(uid string) (*models.V1Project, error) {
 }
 
 func (h *V1Client) GetProjects() (*models.V1ProjectsMetadata, error) {
-	params := clientV1.NewV1ProjectsMetadataParamsWithContext(h.ctx)
+	// ACL scoped to tenant only
+	params := clientV1.NewV1ProjectsMetadataParams()
 	resp, err := h.Client.V1ProjectsMetadata(params)
 	if err != nil {
 		return nil, err
@@ -52,7 +58,8 @@ func (h *V1Client) GetProjects() (*models.V1ProjectsMetadata, error) {
 }
 
 func (h *V1Client) UpdateProject(uid string, body *models.V1ProjectEntity) error {
-	params := clientV1.NewV1ProjectsUIDUpdateParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1ProjectsUIDUpdateParams().
 		WithUID(uid).
 		WithBody(body)
 	_, err := h.Client.V1ProjectsUIDUpdate(params)
@@ -60,7 +67,8 @@ func (h *V1Client) UpdateProject(uid string, body *models.V1ProjectEntity) error
 }
 
 func (h *V1Client) DeleteProject(uid string) error {
-	params := clientV1.NewV1ProjectsUIDDeleteParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1ProjectsUIDDeleteParams().
 		WithUID(uid)
 	_, err := h.Client.V1ProjectsUIDDelete(params)
 	return err

--- a/client/role.go
+++ b/client/role.go
@@ -7,8 +7,12 @@ import (
 	"github.com/spectrocloud/palette-api-go/models"
 )
 
+// CRUDL operations on roles are all tenant scoped.
+// See: hubble/services/service/user/internal/service/role/role_acl.go
+
 func (h *V1Client) GetRole(roleName string) (*models.V1Role, error) {
-	params := clientV1.NewV1RolesListParamsWithContext(h.ctx)
+	// ACL scoped to tenant only
+	params := clientV1.NewV1RolesListParams()
 	resp, err := h.Client.V1RolesList(params)
 	if err != nil {
 		return nil, err

--- a/client/team.go
+++ b/client/team.go
@@ -5,8 +5,12 @@ import (
 	"github.com/spectrocloud/palette-api-go/models"
 )
 
+// CRUDL operations on teams are all tenant scoped.
+// See: hubble/services/svccore/perms/user_acl.go
+
 func (h *V1Client) CreateTeam(team *models.V1Team) (string, error) {
-	params := clientV1.NewV1TeamsCreateParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1TeamsCreateParams().
 		WithBody(team)
 	resp, err := h.Client.V1TeamsCreate(params)
 	if err != nil {
@@ -16,7 +20,8 @@ func (h *V1Client) CreateTeam(team *models.V1Team) (string, error) {
 }
 
 func (h *V1Client) UpdateTeam(uid string, team *models.V1Team) error {
-	params := clientV1.NewV1TeamsUIDUpdateParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1TeamsUIDUpdateParams().
 		WithUID(uid).
 		WithBody(team)
 	_, err := h.Client.V1TeamsUIDUpdate(params)
@@ -24,7 +29,8 @@ func (h *V1Client) UpdateTeam(uid string, team *models.V1Team) error {
 }
 
 func (h *V1Client) GetTeam(uid string) (*models.V1Team, error) {
-	params := clientV1.NewV1TeamsUIDGetParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1TeamsUIDGetParams().
 		WithUID(uid)
 	resp, err := h.Client.V1TeamsUIDGet(params)
 	if err != nil {
@@ -34,7 +40,8 @@ func (h *V1Client) GetTeam(uid string) (*models.V1Team, error) {
 }
 
 func (h *V1Client) DeleteTeam(uid string) error {
-	params := clientV1.NewV1TeamsUIDDeleteParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1TeamsUIDDeleteParams().
 		WithUID(uid)
 	_, err := h.Client.V1TeamsUIDDelete(params)
 	return err

--- a/client/user.go
+++ b/client/user.go
@@ -8,8 +8,12 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/client/apiutil"
 )
 
+// CRUDL operations on users are all tenant scoped.
+// See: hubble/services/svccore/perms/user_acl.go
+
 func (h *V1Client) GetUsers() (*models.V1Users, error) {
-	params := clientV1.NewV1UsersListParamsWithContext(h.ctx).
+	// ACL scoped to tenant only
+	params := clientV1.NewV1UsersListParams().
 		WithLimit(apiutil.Ptr(int64(0)))
 	resp, err := h.Client.V1UsersList(params)
 	if err != nil {


### PR DESCRIPTION
Hubble rejects project-scoped API calls to certain endpoints. This PR removes projectUids from all impacted methods and documents which methods may be impacted in the future, should we add SDK support for those APIs.