### PR TITLE
feat: api key and standardization of uid action

### DIFF
--- a/client/api_key.go
+++ b/client/api_key.go
@@ -2,3 +2,42 @@ package client
 
 // CRUDL operations on API keys are all tenant scoped.
 // See: hubble/services/service/user/internal/service/apikey/apikey_acl.go
+
+import (
+	"fmt"
+
+	clientv1 "github.com/spectrocloud/palette-sdk-go/api/client/v1"
+	"github.com/spectrocloud/palette-sdk-go/api/models"
+)
+
+func (h *V1Client) GetAPIKeys() (*models.V1APIKeys, error) {
+	params := clientv1.NewV1APIKeysListParams()
+	resp, err := h.Client.V1APIKeysList(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Payload, nil
+}
+
+func (h *V1Client) DeleteAPIKeyByName(name string) error {
+	keys, err := h.GetAPIKeys()
+	if err != nil {
+		return err
+	}
+	for _, key := range keys.Items {
+		if key.Metadata.Name == name {
+			return h.DeleteAPIKey(key.Metadata.UID)
+		}
+	}
+	return fmt.Errorf("api key with name '%s' not found", name)
+}
+
+func (h *V1Client) DeleteAPIKey(uid string) error {
+	params := clientv1.NewV1APIKeysUIDDeleteParams().WithUID(uid)
+	_, err := h.Client.V1APIKeysUIDDelete(params)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/client/api_key.go
+++ b/client/api_key.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spectrocloud/palette-sdk-go/api/models"
 )
 
+// GetAPIKeys retrieves all API Keys.
 func (h *V1Client) GetAPIKeys() (*models.V1APIKeys, error) {
 	params := clientv1.NewV1APIKeysListParams()
 	resp, err := h.Client.V1APIKeysList(params)
@@ -20,6 +21,7 @@ func (h *V1Client) GetAPIKeys() (*models.V1APIKeys, error) {
 	return resp.Payload, nil
 }
 
+// DeleteAPIKeyByName deletes an existing API Key by name.
 func (h *V1Client) DeleteAPIKeyByName(name string) error {
 	keys, err := h.GetAPIKeys()
 	if err != nil {
@@ -33,6 +35,7 @@ func (h *V1Client) DeleteAPIKeyByName(name string) error {
 	return fmt.Errorf("api key with name '%s' not found", name)
 }
 
+// DeleteAPIKey deletes an existing API Key by UID.
 func (h *V1Client) DeleteAPIKey(uid string) error {
 	params := clientv1.NewV1APIKeysUIDDeleteParams().WithUID(uid)
 	_, err := h.Client.V1APIKeysUIDDelete(params)

--- a/client/project.go
+++ b/client/project.go
@@ -38,7 +38,7 @@ func (h *V1Client) GetProjectUID(projectName string) (string, error) {
 	return "", fmt.Errorf("project '%s' not found", projectName)
 }
 
-// GetProjectByUID retrieves an existing project by UID.
+// GetProject retrieves an existing project by UID.
 func (h *V1Client) GetProject(uid string) (*models.V1Project, error) {
 	// ACL scoped to tenant only
 	params := clientv1.NewV1ProjectsUIDGetParams().

--- a/client/project.go
+++ b/client/project.go
@@ -39,7 +39,7 @@ func (h *V1Client) GetProjectUID(projectName string) (string, error) {
 }
 
 // GetProjectByUID retrieves an existing project by UID.
-func (h *V1Client) GetProjectByUID(uid string) (*models.V1Project, error) {
+func (h *V1Client) GetProject(uid string) (*models.V1Project, error) {
 	// ACL scoped to tenant only
 	params := clientv1.NewV1ProjectsUIDGetParams().
 		WithUID(uid)

--- a/client/ssh_key.go
+++ b/client/ssh_key.go
@@ -42,7 +42,7 @@ func (h *V1Client) GetSSHKeyByName(name string) (*models.V1UserAssetSSH, error) 
 	return nil, fmt.Errorf("ssh key '%s' not found", name)
 }
 
-// GetSSHKeyByUID retrieves an existing SSH key by UID.
+// GetSSHKey retrieves an existing SSH key by UID.
 func (h *V1Client) GetSSHKey(uid string) (*models.V1UserAssetSSH, error) {
 	params := clientv1.NewV1UsersAssetSSHGetUIDParamsWithContext(h.ctx).
 		WithUID(uid)

--- a/client/ssh_key.go
+++ b/client/ssh_key.go
@@ -43,7 +43,7 @@ func (h *V1Client) GetSSHKeyByName(name string) (*models.V1UserAssetSSH, error) 
 }
 
 // GetSSHKeyByUID retrieves an existing SSH key by UID.
-func (h *V1Client) GetSSHKeyByUID(uid string) (*models.V1UserAssetSSH, error) {
+func (h *V1Client) GetSSHKey(uid string) (*models.V1UserAssetSSH, error) {
 	params := clientv1.NewV1UsersAssetSSHGetUIDParamsWithContext(h.ctx).
 		WithUID(uid)
 	resp, err := h.Client.V1UsersAssetSSHGetUID(params)

--- a/client/user.go
+++ b/client/user.go
@@ -85,7 +85,7 @@ func (h *V1Client) GetUserByEmail(email string) (*models.V1User, error) {
 }
 
 // DeleteUserByUID deletes an existing user by UID.
-func (h *V1Client) DeleteUserByUID(uid string) error {
+func (h *V1Client) DeleteUser(uid string) error {
 	params := clientv1.NewV1UsersUIDDeleteParams().WithUID(uid)
 	_, err := h.Client.V1UsersUIDDelete(params)
 	if err != nil {
@@ -102,7 +102,7 @@ func (h *V1Client) DeleteUserByName(name string) error {
 	}
 	for _, user := range users.Items {
 		if user.Metadata.Name == name {
-			return h.DeleteUserByUID(user.Metadata.UID)
+			return h.DeleteUser(user.Metadata.UID)
 		}
 	}
 	return fmt.Errorf("user with name '%s' not found", name)

--- a/client/user.go
+++ b/client/user.go
@@ -84,7 +84,7 @@ func (h *V1Client) GetUserByEmail(email string) (*models.V1User, error) {
 	return nil, fmt.Errorf("user with email '%s' not found", email)
 }
 
-// DeleteUserByUID deletes an existing user by UID.
+// DeleteUser deletes an existing user by UID.
 func (h *V1Client) DeleteUser(uid string) error {
 	params := clientv1.NewV1UsersUIDDeleteParams().WithUID(uid)
 	_, err := h.Client.V1UsersUIDDelete(params)


### PR DESCRIPTION
## Summary

Adding the below functions to support user interactions with API tokens via SDK.

```
func (h *V1Client) GetAPIKeys() (*models.V1APIKeys, error) {}
func (h *V1Client) DeleteAPIKeyByName(name string) error {}
func (h *V1Client) DeleteAPIKey(uid string) error {}
```

## Other Changes
References of DoX**ByUID** changed to just DoX as there are more refernces of DoX then DoXByUID.

Examples are `DeleteProject(uid string)` `GetTeam(uid string)` `GetPack(uid string)` 

To note, searching all these changed functions I have not found any other project within SpectroCloud which utilizes these functions. 

