### PR TITLE
feat: validate edge cluster; functional option for client context

### DIFF
--- a/client/addon_deployment_update.go
+++ b/client/addon_deployment_update.go
@@ -17,7 +17,7 @@ func (h *V1Client) UpdateAddonDeployment(cluster *models.V1SpectroCluster, body 
 
 	resolveNotifications := true
 	params := clientv1.NewV1SpectroClustersPatchProfilesParams().
-		WithContext(ContextForScope(cluster.Metadata.Annotations[Scope], h.projectUID)).
+		WithContext(ContextForScope(h.baseCtx, cluster.Metadata.Annotations[Scope], h.projectUID)).
 		WithUID(uid).
 		WithBody(body).
 		WithResolveNotification(&resolveNotifications)
@@ -39,7 +39,7 @@ func IsProfileAttachedByName(cluster *models.V1SpectroCluster, newProfile *model
 func (h *V1Client) CreateAddonDeployment(cluster *models.V1SpectroCluster, body *models.V1SpectroClusterProfiles) error {
 	resolveNotifications := false // during initial creation we never need to resolve packs
 	params := clientv1.NewV1SpectroClustersPatchProfilesParams().
-		WithContext(ContextForScope(cluster.Metadata.Annotations[Scope], h.projectUID)).
+		WithContext(ContextForScope(h.baseCtx, cluster.Metadata.Annotations[Scope], h.projectUID)).
 		WithUID(cluster.Metadata.UID).
 		WithBody(body).
 		WithResolveNotification(&resolveNotifications)

--- a/client/application_profile.go
+++ b/client/application_profile.go
@@ -178,7 +178,7 @@ func (h *V1Client) DeleteApplicationProfile(uid string) error {
 		return err
 	}
 	params := clientv1.NewV1AppProfilesUIDDeleteParams().
-		WithContext(ContextForScope(profile.Metadata.Annotations[Scope], h.projectUID)).
+		WithContext(ContextForScope(h.baseCtx, profile.Metadata.Annotations[Scope], h.projectUID)).
 		WithUID(uid)
 	_, err = h.Client.V1AppProfilesUIDDelete(params)
 	return err

--- a/client/cluster_edge_native.go
+++ b/client/cluster_edge_native.go
@@ -229,6 +229,14 @@ func (h *V1Client) CreateClusterEdgeNative(cluster *models.V1SpectroEdgeNativeCl
 	return *resp.Payload.UID, nil
 }
 
+// ValidateClusterEdgeNative validates an edge native cluster creation payload.
+func (h *V1Client) ValidateClusterEdgeNative(cluster *models.V1SpectroEdgeNativeClusterEntity) error {
+	params := clientv1.NewV1SpectroClustersEdgeNativeValidateParamsWithContext(h.ctx).
+		WithBody(cluster)
+	_, err := h.Client.V1SpectroClustersEdgeNativeValidate(params)
+	return err
+}
+
 // CreateMachinePoolEdgeNative creates a new edge native machine pool.
 func (h *V1Client) CreateMachinePoolEdgeNative(cloudConfigUID string, machinePool *models.V1EdgeNativeMachinePoolConfigEntity) error {
 	params := clientv1.NewV1CloudConfigsEdgeNativeMachinePoolCreateParamsWithContext(h.ctx).

--- a/client/virtual_machine.go
+++ b/client/virtual_machine.go
@@ -41,7 +41,7 @@ func (h *V1Client) GetVirtualMachine(uid, namespace, name string) (*models.V1Clu
 func (h *V1Client) UpdateVirtualMachine(cluster *models.V1SpectroCluster, vmName string, body *models.V1ClusterVirtualMachine) (*models.V1ClusterVirtualMachine, error) {
 	clusterUID := cluster.Metadata.UID
 	params := clientv1.NewV1SpectroClustersVMUpdateParams().
-		WithContext(ContextForScope(cluster.Metadata.Annotations[Scope], h.projectUID)).
+		WithContext(ContextForScope(h.baseCtx, cluster.Metadata.Annotations[Scope], h.projectUID)).
 		WithUID(clusterUID).
 		WithBody(body).
 		WithNamespace(body.Metadata.Namespace).

--- a/client/virtual_machine_common.go
+++ b/client/virtual_machine_common.go
@@ -33,7 +33,7 @@ func (h *V1Client) GetVirtualMachineWithoutStatus(uid, name, namespace string) (
 // GetVirtualMachines retrieves a list of virtual machines for a given cluster.
 func (h *V1Client) GetVirtualMachines(cluster *models.V1SpectroCluster) ([]*models.V1ClusterVirtualMachine, error) {
 	params := clientv1.NewV1SpectroClustersVMListParams().
-		WithContext(ContextForScope(cluster.Metadata.Annotations[Scope], h.projectUID)).
+		WithContext(ContextForScope(h.baseCtx, cluster.Metadata.Annotations[Scope], h.projectUID)).
 		WithUID(cluster.Metadata.UID)
 	resp, err := h.Client.V1SpectroClustersVMList(params)
 	if err != nil {


### PR DESCRIPTION
This PR:

- Exposes a new method, `ValidateClusterEdgeNative`, for pre-validating edge cluster creation payloads
- Adds support for configuring the client context