### PR TITLE
feat: add CloneClusterProfile client method (#205)

### DIFF
--- a/client/cluster_profile.go
+++ b/client/cluster_profile.go
@@ -297,6 +297,19 @@ func (h *V1Client) CreateClusterProfile(clusterProfile *models.V1ClusterProfileE
 	return *resp.Payload.UID, nil
 }
 
+// CloneClusterProfile clones an existing cluster profile to create a new version.
+// The new version is a separate Palette object with its own UID, grouped by name.
+func (h *V1Client) CloneClusterProfile(uid string, body *models.V1ClusterProfileCloneEntity) (string, error) {
+	params := clientv1.NewV1ClusterProfilesUIDCloneParamsWithContext(h.ctx).
+		WithUID(uid).
+		WithBody(body)
+	resp, err := h.Client.V1ClusterProfilesUIDClone(params)
+	if err != nil {
+		return "", err
+	}
+	return *resp.Payload.UID, nil
+}
+
 // PublishClusterProfile publishes an existing cluster profile.
 // TODO: what does it mean to publish a cluster profile?
 func (h *V1Client) PublishClusterProfile(uid string) error {


### PR DESCRIPTION
Exposes the existing POST /v1/clusterprofiles/{uid}/clone endpoint via the higher-level V1Client wrapper. The auto-generated swagger structs already exist but were not wired up.