### PR TITLE
fix: redact api keys in auth ResourceNotFound errors

### DIFF
--- a/api/apiutil/transport/runtime.go
+++ b/api/apiutil/transport/runtime.go
@@ -571,8 +571,8 @@ type redactedError struct {
 	message  string
 }
 
-func (e *redactedError) Error() string  { return e.message }
-func (e *redactedError) Unwrap() error  { return e.original }
+func (e *redactedError) Error() string { return e.message }
+func (e *redactedError) Unwrap() error { return e.original }
 
 // AddSensitiveValue registers a value that should be redacted from error messages.
 func (r *Runtime) AddSensitiveValue(value string) {

--- a/api/apiutil/transport/runtime.go
+++ b/api/apiutil/transport/runtime.go
@@ -219,9 +219,10 @@ type Runtime struct {
 	Formats  strfmt.Registry
 	Context  context.Context
 
-	RetryAttempts int
-	Debug         bool
-	logger        logger.Logger
+	RetryAttempts   int
+	Debug           bool
+	logger          logger.Logger
+	sensitiveValues []string
 
 	clientOnce *sync.Once
 	client     *http.Client
@@ -542,9 +543,11 @@ func (r *Runtime) submitRequest(operation *runtime.ClientOperation) (interface{}
 	if res.StatusCode >= 200 && res.StatusCode <= 399 {
 		return readResponse.ReadResponse(response{res}, cons)
 	} else if res.StatusCode == http.StatusTooManyRequests {
-		return ReadTooManyRequestError(req.Method, req.URL.Path)
+		result, err := ReadTooManyRequestError(req.Method, req.URL.Path)
+		return result, r.redactError(err)
 	} else {
-		return ReadErrorResponse(response{res}, cons)
+		result, err := ReadErrorResponse(response{res}, cons)
+		return result, r.redactError(err)
 	}
 }
 
@@ -559,6 +562,40 @@ func (r *Runtime) getDefaultTimeOut(request *request) time.Duration {
 func printMsg(m string) string {
 	fmt.Println(m)
 	return m
+}
+
+// AddSensitiveValue registers a value that should be redacted from error messages.
+func (r *Runtime) AddSensitiveValue(value string) {
+	if value != "" {
+		r.sensitiveValues = append(r.sensitiveValues, value)
+	}
+}
+
+// redactError replaces any registered sensitive values in err with [REDACTED].
+// For TransportError, the payload fields are also redacted in-place.
+func (r *Runtime) redactError(err error) error {
+	if err == nil || len(r.sensitiveValues) == 0 {
+		return err
+	}
+	if te, ok := err.(*TransportError); ok {
+		if te.Payload != nil {
+			for _, v := range r.sensitiveValues {
+				te.Payload.Message = strings.ReplaceAll(te.Payload.Message, v, "[REDACTED]")
+				if s, ok := te.Payload.Details.(string); ok {
+					te.Payload.Details = strings.ReplaceAll(s, v, "[REDACTED]")
+				}
+			}
+		}
+		return te
+	}
+	msg := err.Error()
+	for _, v := range r.sensitiveValues {
+		msg = strings.ReplaceAll(msg, v, "[REDACTED]")
+	}
+	if msg == err.Error() {
+		return err
+	}
+	return errors.New(msg)
 }
 
 // SetDebug changes the debug flag.

--- a/api/apiutil/transport/runtime.go
+++ b/api/apiutil/transport/runtime.go
@@ -564,6 +564,16 @@ func printMsg(m string) string {
 	return m
 }
 
+// redactedError wraps an original error with a redacted message string.
+// Unwrap returns the original so errors.Is/As continue to work.
+type redactedError struct {
+	original error
+	message  string
+}
+
+func (e *redactedError) Error() string  { return e.message }
+func (e *redactedError) Unwrap() error  { return e.original }
+
 // AddSensitiveValue registers a value that should be redacted from error messages.
 func (r *Runtime) AddSensitiveValue(value string) {
 	if value != "" {
@@ -571,31 +581,60 @@ func (r *Runtime) AddSensitiveValue(value string) {
 	}
 }
 
+// redactString replaces all sensitive values in s with [REDACTED].
+func redactString(s string, sensitiveValues []string) string {
+	for _, v := range sensitiveValues {
+		s = strings.ReplaceAll(s, v, "[REDACTED]")
+	}
+	return s
+}
+
+// redactValue recursively redacts sensitive values from JSON-like structures
+// (string, map[string]any, []any) that may have been decoded into interface{}.
+func redactValue(v interface{}, sensitiveValues []string) interface{} {
+	switch val := v.(type) {
+	case string:
+		return redactString(val, sensitiveValues)
+	case map[string]interface{}:
+		for k, mv := range val {
+			val[k] = redactValue(mv, sensitiveValues)
+		}
+		return val
+	case []interface{}:
+		for i, item := range val {
+			val[i] = redactValue(item, sensitiveValues)
+		}
+		return val
+	}
+	return v
+}
+
 // redactError replaces any registered sensitive values in err with [REDACTED].
-// For TransportError, the payload fields are also redacted in-place.
+// For TransportError, a shallow copy is returned with a redacted payload so the
+// original error object is never mutated.
+// Non-TransportError errors are wrapped in a redactedError that preserves Unwrap.
 func (r *Runtime) redactError(err error) error {
 	if err == nil || len(r.sensitiveValues) == 0 {
 		return err
 	}
 	if te, ok := err.(*TransportError); ok {
-		if te.Payload != nil {
-			for _, v := range r.sensitiveValues {
-				te.Payload.Message = strings.ReplaceAll(te.Payload.Message, v, "[REDACTED]")
-				if s, ok := te.Payload.Details.(string); ok {
-					te.Payload.Details = strings.ReplaceAll(s, v, "[REDACTED]")
-				}
-			}
+		if te.Payload == nil {
+			return te
 		}
-		return te
+		redactedPayload := *te.Payload
+		redactedPayload.Message = redactString(te.Payload.Message, r.sensitiveValues)
+		redactedPayload.Details = redactValue(te.Payload.Details, r.sensitiveValues)
+		return &TransportError{
+			Payload:  &redactedPayload,
+			HttpCode: te.HttpCode,
+		}
 	}
-	msg := err.Error()
-	for _, v := range r.sensitiveValues {
-		msg = strings.ReplaceAll(msg, v, "[REDACTED]")
-	}
-	if msg == err.Error() {
+	original := err.Error()
+	redacted := redactString(original, r.sensitiveValues)
+	if redacted == original {
 		return err
 	}
-	return errors.New(msg)
+	return &redactedError{original: err, message: redacted}
 }
 
 // SetDebug changes the debug flag.

--- a/client/client.go
+++ b/client/client.go
@@ -209,12 +209,14 @@ func (h *V1Client) getTransport() *transport.Runtime {
 func (h *V1Client) apiKeyTransport() *transport.Runtime {
 	httpTransport := h.baseTransport()
 	httpTransport.DefaultAuthentication = openapiclient.APIKeyAuth(authAPIKey, authTokenInput, h.apikey)
+	httpTransport.AddSensitiveValue(h.apikey)
 	return httpTransport
 }
 
 func (h *V1Client) jwtTransport() *transport.Runtime {
 	httpTransport := h.baseTransport()
 	httpTransport.DefaultAuthentication = openapiclient.APIKeyAuth(authJwt, authTokenInput, h.jwt)
+	httpTransport.AddSensitiveValue(h.jwt)
 	return httpTransport
 }
 


### PR DESCRIPTION
Authentication errors with ResourceNotFound can leak the sent jwt into the error mesage of the response. We need to redact these keys before they are sent back to consumers.