### PR TITLE
PAI-311: fix(client): propagate rootCAs through Clone()

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -144,10 +144,15 @@ func WithTransportDebug() func(*V1Client) {
 	}
 }
 
-// WithRootCAs sets root CAs for the client.
+// WithRootCAs sets root CAs for the client. The supplied pool is cloned, so
+// mutating it after this call has no effect on the client's trust store, and
+// callers holding a reference to the same pool across multiple clients can't
+// accidentally share mutable trust state.
 func WithRootCAs(rootCAs *x509.CertPool) func(*V1Client) {
 	return func(v *V1Client) {
-		v.rootCAs = rootCAs
+		if rootCAs != nil {
+			v.rootCAs = rootCAs.Clone()
+		}
 	}
 }
 
@@ -190,6 +195,9 @@ func (h *V1Client) Clone() *V1Client {
 	}
 	if h.transportDebug {
 		opts = append(opts, WithTransportDebug())
+	}
+	if h.rootCAs != nil {
+		opts = append(opts, WithRootCAs(h.rootCAs))
 	}
 	return New(opts...)
 }

--- a/client/client_rootcas_test.go
+++ b/client/client_rootcas_test.go
@@ -114,6 +114,13 @@ func TestClone_PropagatesRootCAs(t *testing.T) {
 	// beyond the system pool even though the original client worked fine.
 	require.NotNil(t, cloned.rootCAs, "Clone() must propagate rootCAs — this was the bug: Clone() never called WithRootCAs")
 	assert.NotSame(t, c.rootCAs, cloned.rootCAs, "Clone() must clone the pool again, not share the original client's pointer")
+
+	// The non-nil/not-same checks above prove Clone() carries a distinct
+	// rootCAs value, but not that the clone can actually complete a TLS
+	// handshake with it — Clone() preserves paletteURI/schemes from h, so
+	// this reaches the same test server the original client did.
+	_, err = cloned.Client.V1ProjectsMetadata(nil)
+	assert.NoError(t, err, "cloned client must be able to complete a real TLS handshake using its propagated rootCAs")
 }
 
 func TestClone_PlainSaaSClient_NoRootCAs_Unaffected(t *testing.T) {

--- a/client/client_rootcas_test.go
+++ b/client/client_rootcas_test.go
@@ -1,0 +1,132 @@
+package client
+
+import (
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTLSTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.Header().Set("Content-Type", "application/json")
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func poolFor(servers ...*httptest.Server) *x509.CertPool {
+	pool := x509.NewCertPool()
+	for _, s := range servers {
+		pool.AddCert(s.Certificate())
+	}
+	return pool
+}
+
+func hostOf(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+	return strings.TrimPrefix(server.URL, "https://")
+}
+
+// canReach returns true if a client built with the given options can
+// successfully complete a request against server, false if the TLS
+// handshake (or the request itself) fails.
+func canReach(t *testing.T, server *httptest.Server, opts ...func(*V1Client)) bool {
+	t.Helper()
+	base := []func(*V1Client){
+		WithPaletteURI(hostOf(t, server)),
+		WithSchemes([]string{"https"}),
+	}
+	c := New(append(base, opts...)...)
+	_, err := c.Client.V1ProjectsMetadata(nil)
+	return err == nil
+}
+
+func TestHTTPClient_NilRootCAs_UsesSystemDefault(t *testing.T) {
+	server := newTLSTestServer(t)
+
+	// No WithRootCAs option at all — a self-signed test-server cert is not
+	// in the system trust store, so the request must fail. This is the
+	// SaaS-path regression check: existing callers who never touch this
+	// option must see unchanged, strict verification.
+	assert.False(t, canReach(t, server), "client with no RootCAs must not trust a self-signed cert")
+}
+
+func TestHTTPClient_RootCAs_TrustsOnlySuppliedCA(t *testing.T) {
+	server := newTLSTestServer(t)
+	pool := poolFor(server)
+
+	assert.True(t, canReach(t, server, WithRootCAs(pool)), "client with the server's CA in RootCAs must trust it")
+}
+
+func TestWithRootCAs_ClonesInput(t *testing.T) {
+	serverA := newTLSTestServer(t)
+	serverB := newTLSTestServer(t)
+
+	pool := poolFor(serverA)
+	c := New(
+		WithPaletteURI(hostOf(t, serverA)),
+		WithSchemes([]string{"https"}),
+		WithRootCAs(pool),
+	)
+
+	// Mutate the caller's pool AFTER handing it to WithRootCAs. If the
+	// option stored the pointer directly (no defensive clone), this
+	// mutation leaks into the client's trust store.
+	pool.AddCert(serverB.Certificate())
+
+	_, err := c.Client.V1ProjectsMetadata(nil)
+	assert.NoError(t, err, "client must still trust serverA after the external pool was mutated")
+
+	// Directly verify c's internal pool is a distinct object from the
+	// caller's pool — the mutation above must not have reached it.
+	assert.NotSame(t, pool, c.rootCAs, "WithRootCAs must clone the supplied pool, not store the caller's pointer")
+}
+
+func TestClone_PropagatesRootCAs(t *testing.T) {
+	server := newTLSTestServer(t)
+	pool := poolFor(server)
+
+	c := New(
+		WithPaletteURI(hostOf(t, server)),
+		WithSchemes([]string{"https"}),
+		WithRootCAs(pool),
+	)
+	_, err := c.Client.V1ProjectsMetadata(nil)
+	require.NoError(t, err, "sanity: original client must trust the server before cloning")
+
+	cloned := c.Clone()
+	// Clone() rebuilds paletteURI/scheme from tenant scope defaults, so the
+	// meaningful assertion isn't "same host" (Clone always resets to
+	// WithScopeTenant with the original paletteURI) — it's that the CLONE
+	// actually carries rootCAs at all. Before the fix, Clone()'s option
+	// list never included WithRootCAs, so cloned.rootCAs was always nil
+	// regardless of h.rootCAs, and the clone would fail to trust anything
+	// beyond the system pool even though the original client worked fine.
+	require.NotNil(t, cloned.rootCAs, "Clone() must propagate rootCAs — this was the bug: Clone() never called WithRootCAs")
+	assert.NotSame(t, c.rootCAs, cloned.rootCAs, "Clone() must clone the pool again, not share the original client's pointer")
+}
+
+func TestClone_PlainSaaSClient_NoRootCAs_Unaffected(t *testing.T) {
+	// A client that never set WithRootCAs (the plain-SaaS case, unchanged
+	// by this patch) must still Clone() cleanly with rootCAs left nil —
+	// the `if h.rootCAs != nil` guard in Clone() must not, say, panic on a
+	// nil pool or otherwise regress the pre-existing SaaS Clone() path.
+	c := New(
+		WithPaletteURI("console.spectrocloud.com"),
+		WithAPIKey("fake-key-not-used-over-the-wire"),
+	)
+	if c.rootCAs != nil {
+		t.Fatalf("sanity: expected nil rootCAs on a client that never called WithRootCAs, got %v", c.rootCAs)
+	}
+
+	cloned := c.Clone()
+	assert.Nil(t, cloned.rootCAs, "Clone() of a plain-SaaS client must leave rootCAs nil, not introduce one")
+}

--- a/client/client_rootcas_test.go
+++ b/client/client_rootcas_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testScheme = "https"
+
 func newTLSTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	server := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
@@ -42,7 +44,7 @@ func canReach(t *testing.T, server *httptest.Server, opts ...func(*V1Client)) bo
 	t.Helper()
 	base := []func(*V1Client){
 		WithPaletteURI(hostOf(t, server)),
-		WithSchemes([]string{"https"}),
+		WithSchemes([]string{testScheme}),
 	}
 	c := New(append(base, opts...)...)
 	_, err := c.Client.V1ProjectsMetadata(nil)
@@ -73,7 +75,7 @@ func TestWithRootCAs_ClonesInput(t *testing.T) {
 	pool := poolFor(serverA)
 	c := New(
 		WithPaletteURI(hostOf(t, serverA)),
-		WithSchemes([]string{"https"}),
+		WithSchemes([]string{testScheme}),
 		WithRootCAs(pool),
 	)
 
@@ -96,7 +98,7 @@ func TestClone_PropagatesRootCAs(t *testing.T) {
 
 	c := New(
 		WithPaletteURI(hostOf(t, server)),
-		WithSchemes([]string{"https"}),
+		WithSchemes([]string{testScheme}),
 		WithRootCAs(pool),
 	)
 	_, err := c.Client.V1ProjectsMetadata(nil)


### PR DESCRIPTION
## Summary
- `WithRootCAs` already existed (#190) and was correctly wired into `httpClient()`'s `TLSClientConfig`, but `Clone()` never included it in the options list it rebuilds a new client from — a cloned client silently lost trust in a pinned CA even though the original client worked fine against the same host.
- `WithRootCAs` now defensively clones the supplied pool (`pool.Clone()`) instead of storing the caller's pointer directly, so mutating the caller's pool after construction can't leak into the client's trust store, and cannot leak between two independent clients sharing a source pool.

## Why
Needed by `palette-mcp-server`'s self-hosted Palette support (PAI-311), which fetches a self-hosted install's CA and must propagate that trust to every SDK client it constructs — including the per-project-scoped clients that `scopedV1()`-style callers rebuild via `Clone()`-equivalent option lists.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] 5 new tests added in `client/client_rootcas_test.go`: nil-RootCAs preserves default trust (SaaS regression check), RootCAs trusts only the supplied CA, `WithRootCAs` clones its input (mutation-after-handoff doesn't leak), `Clone()` propagates `rootCAs` (the actual bug fix, verified functionally via a real TLS handshake, not just a field check), and `Clone()` of a plain client that never set `RootCAs` leaves it nil (SaaS-path regression check on the fix itself)
- [x] Verified two of the new tests actually fail against the pre-fix code (reverted the fix locally, confirmed failures, restored it) — not vacuous assertions
- [x] Full `client` package suite passes under `-race`: 16/16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS trust handling by safely cloning custom root CA pools to avoid shared mutable state.
  * Updated client cloning so configured root CA settings are preserved, while clients without custom CAs stay unchanged.
  * Added defensive handling for absent custom CA pools to ensure predictable connection behavior.
* **Tests**
  * Added TLS root CA tests validating reachability with/without custom roots, clone propagation, and protection against later certificate-pool mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->